### PR TITLE
Adding RegExp support for more matching possibilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = function hideStackFramesFrom() {
     chain.filter.attach(function(error, frames) {
       return frames.filter(function(frame) {
         var f = frame.getFileName()
+        if (name instanceof RegExp) {
+            return !name.test(f)
+        }
         return f.indexOf('node_modules/' + name + '/') === -1 &&
                f.indexOf('node_modules\\' + name + '\\') === -1
       })


### PR DESCRIPTION
Wanted to be able to filter out lines like this, too:

```
  at Object.invoke (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:4118:17)
  at runInvokeQueue (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:4024:35)
  at /Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:4033:11
  at forEach (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:339:20)
  at loadModules (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:4014:5)
  at createInjector (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:3940:11)
  at doBootstrap (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:1451:20)
  at Object.bootstrap (/Users/milan/sandbox/repos/html-client/http-pub/bower/angular/angular.js:1472:12)
  at Object.myStepDefinitionsWrapper (/Users/milan/sandbox/repos/html-client/features/steps.js:139:29)
  at /Users/milan/.nvm/v0.10.22/lib/node_modules/cucumber/lib/cucumber/cli/support_code_loader.js:60:25
```

With this patch, it is possible:

```
hideStackFramesFrom('cucumber', /angular.js/)
```
